### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: "alkali-csd-fw"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "submodules"
+
+  - package-ecosystem: gitsubmodule
+    directory: "alkali-csd-hw"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "submodules"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "alkali-csd-hw"]
 	path = alkali-csd-hw
 	url = ../alkali-csd-hw.git
+	branch = main
 [submodule "alkali-csd-fw"]
 	path = alkali-csd-fw
 	url = ../alkali-csd-fw.git
+	branch = main
 [submodule "third-party/embeddedsw"]
 	path = third-party/embeddedsw
 	url = https://github.com/Xilinx/embeddedsw/


### PR DESCRIPTION
This PR adds dependabot for managing `alkali-csd-fw` and `alkali-csd-hw` submodules