### PR TITLE
Ensure building all the prerequisites for examples in the docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 # -----------------------------------------------------------------------------
 
 .PHONY: all
-all: sdcard example/build  ## Build all system components for the specified board
+all: sdcard example/build host-app ## Build all system components for the specified board
 
 # -----------------------------------------------------------------------------
 # Clean -----------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,8 @@ example/load: $(EXAMPLE_OUTPUT_FILE) ## Load example specified by EXAMPLE to nvm
 
 .PHONY: example/build
 example/build: $(EXAMPLE_INPUT_FILE) ## Build example specified by EXAMPLE to nvme device specified by NVME_DEVICE
+example/build: $(EXAMPLE_BPF_OBJECT_FILE)
+example/build: $(HOSTAPP_OUTPUTS)
 
 $(EXAMPLE_BUILD_DIR):
 	@mkdir -p $@

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ you can build and load one of the tests from the `examples/` directory to
 the NVMe accelerator. To build the example, make sure that you are
 **inside the docker container** and use the following command:
 ```
-EXAMPLE=<example-name> NVME_DEVICE=/dev/<nvme-dev> make example/build
+EXAMPLE=<example-name> make example/build
 ```
 To load the example, make sure that you are **outside the docker container** and use:
 ```
@@ -87,8 +87,9 @@ For instance, if your NVMe accelerator is available as `/dev/nvme1n1`,
 the following commands may be used to build and load the `add` example:
 
 ```bash
-make enter                                               # enter the docker container
-EXAMPLE=add NVME_DEVICE=/dev/nvme1n1 make example/build  # build the example
-exit                                                     # exit the docker container
-EXAMPLE=add NVME_DEVICE=/dev/nvme1n1 make example/load   # upload the example to the board
+make enter                                              # enter the docker container
+make all                                                # build all system components
+EXAMPLE=add make example/build                          # build the example
+exit                                                    # exit the docker container
+EXAMPLE=add NVME_DEVICE=/dev/nvme1n1 make example/load  # upload the example to the board
 ```


### PR DESCRIPTION
This PR ensures that all the prerequisites for examples are build inside the docker container. This includes:
* adding `host-app` to `all` target (and testing its build in the CI)
* adding `bpf` blob and `host-app` to `examples/build` phony target