### PR TITLE
Added installing apu-app dependencies to base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: antmicro/alkali:latest
+      volumes:
+        - /usr/share/dotnet:/usr/share/dotnet
+        - /usr/local/lib/android:/usr/local/lib/android
+        - /opt/ghc:/opt/ghc
     strategy:
       matrix:
         board: [an300, zcu106]
@@ -17,15 +21,23 @@ jobs:
       RELEASE_URL: https://github.com/antmicro/alkali-csd-hw/releases/download/v1.0/${{ matrix.board }}.zip
 
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-
       - name: Install prerequisites
         run: |
           apt update
           apt install -y zip
+      - name: Increase build space
+        run: |
+          echo "Before cleanup"
+          df -H
+          rm -rf /usr/share/dotnet/*
+          rm -rf /usr/local/lib/android/*
+          rm -rf /opt/ghc/*
+          echo "After cleanup"
+          df -H
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Apply workaround for broken Buildroot mirror
         run: echo "1.1.1.1 invisible-mirror.net" | tee -a /etc/hosts

--- a/Makefile
+++ b/Makefile
@@ -276,12 +276,15 @@ $(DOCKER_BUILD_REGGEN_REQS_DIR):
 docker: alkali.dockerfile  ## Build the development docker image
 docker: requirements.txt
 docker: $(FW_ROOT_DIR)/requirements.txt
+docker: $(FW_ROOT_DIR)/apu-app/requirements.txt
 docker: $(REGGEN_DIR)/requirements.txt
 docker: | $(DOCKER_BUILD_REGGEN_REQS_DIR)
 	cp alkali.dockerfile $(DOCKER_BUILD_DIR)/Dockerfile
 	cp $(ROOT_DIR)/requirements.txt $(DOCKER_BUILD_DIR)/requirements.txt
 	mkdir -p $(DOCKER_BUILD_REGGEN_REQS_DIR)
+	mkdir -p $(DOCKER_BUILD_FW_REQS_DIR)/apu-app
 	cp $(FW_ROOT_DIR)/requirements.txt $(DOCKER_BUILD_FW_REQS_DIR)/requirements.txt
+	cp $(FW_ROOT_DIR)/apu-app/requirements.txt $(DOCKER_BUILD_FW_REQS_DIR)/apu-app/requirements.txt
 	cp $(REGGEN_DIR)/requirements.txt $(DOCKER_BUILD_REGGEN_REQS_DIR)/requirements.txt
 	cd $(DOCKER_BUILD_DIR) && docker build \
 		$(DOCKER_BUILD_EXTRA_ARGS) \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ the prerequisites installed locally to use the instructions below correctly.
 Refer to the [#Prerequisites](#prerequisites) section in case of any problems
 with building the project**
 
+Start off with loading the Vivado environment:
+```
+source <path-to-vivado-container>/settings64.sh
+```
+
 Before building any target choose the desired board (`an300` or ` zcu106`),
 by setting the `BOARD` environment variable:
 ```
@@ -67,6 +72,34 @@ after running `make help`. To build all output products use:
 ```
 make all
 ```
+
+# Prepping the SD card for ZCU106 board
+
+In case the board runs from SD card (as in the case of the ZCU106 board), we can run:
+```
+make sdcard
+```
+
+This will create a directory `build/<target>/sdcard` directory with all files needed to run the project on the target.
+
+To prepare the SD card for the system, plug it to the computer and determine its device handle (e.g. `/dev/sdX`, where `X` is the letter corresponding to the SD card).
+
+**NOTE**: It is crucial to correctly determine the device, since the SD card will be wiped before placing files.
+
+After this, run:
+
+```
+./scripts/format-sdcard.sh /dev/<devname>
+```
+
+And conduct the formatting process.
+
+After formatting, there are two partitions:
+
+* `boot` bootable FAT32 partition
+* `root` EXT4 partition
+
+Mount the FAT partition and copy the contents of the `build/<target>/sdcard` directory to this directory.
 
 # Running examples
 

--- a/alkali.dockerfile
+++ b/alkali.dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM debian:buster
+FROM debian:bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
   cpio \
   curl \
   flex \
-  gcc-8 \
+  gcc \
   git \
   gperf \
   libcurl4-openssl-dev \

--- a/alkali.dockerfile
+++ b/alkali.dockerfile
@@ -59,8 +59,9 @@ RUN git clone -b v3.16.7 https://gitlab.kitware.com/cmake/cmake.git cmake && \
 COPY requirements.txt requirements.txt
 COPY alkali-csd-fw/requirements.txt alkali-csd-fw/requirements.txt
 COPY alkali-csd-fw/registers-generator/requirements.txt alkali-csd-fw/registers-generator/requirements.txt
+COPY alkali-csd-fw/apu-app/requirements.txt alkali-csd-fw/apu-app/requirements.txt
 RUN pip3 install -r requirements.txt
-RUN rm requirements.txt alkali-csd-fw/requirements.txt alkali-csd-fw/registers-generator/requirements.txt
+RUN rm requirements.txt alkali-csd-fw/requirements.txt alkali-csd-fw/registers-generator/requirements.txt alkali-csd-fw/apu-app/requirements.txt
 
 # Install Zephyr dependencies
 RUN wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.3/zephyr-sdk-0.10.3-setup.run && \


### PR DESCRIPTION
This MR:

* Bumps `alkali-csd-fm` to the version from https://github.com/antmicro/alkali-csd-fw/pull/7 (it contains the `requirements.txt` for apu-app),
* Bumps base Docker image for alkali to `debian:bullseye`,
* Adds installing requirements for apu-app in the Docker image,
* Updates README.md with instructions on using Vivado and flashing the SD card for ZCU106.