### PR TITLE
Add target for downloading hw prebuilts from GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,19 +44,7 @@ jobs:
 
       - name: Build hardware (without Vivado + prebuilts)
         run: |
-          # Build everything besides running vivado
-          make hardware//chisel
-          # Create fake output directories for make
-          mkdir -p build/hardware/${BOARD}/project_vta/out
-          mkdir -p build/hardware/${BOARD}/chisel_project
-          mkdir -p build/hardware/scala
-          # Download prebuilts
-          wget -O /tmp/${RELEASE_FILE} ${RELEASE_URL}
-          unzip /tmp/${RELEASE_FILE} -d /tmp/
-          cp /tmp/${BOARD}/* build/hardware/${BOARD}/project_vta/out
-          stat build/hardware/${BOARD}/project_vta/out/top.bit build/hardware/${BOARD}/project_vta/out/top.xsa
-          # Fool future make calls by touching hardware targets
-          make -t hardware/all
+          make hardware/all-with-prebuilts
 
       - name: Build firmware
         run: make firmware/all

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,15 @@ $(WEST_YML): # Generate west.yml based on manifest from Firmware repository
 hardware/all: ## Build all Hardware binaries (Vivado design)
 	$(MAKE) -C $(HW_ROOT_DIR) $(HW_MAKE_OPTS) all
 
+.PHONY: hardware/all-with-prebuilts
+hardware/all-with-prebuilts:  ## Build all hardware data, but use prebuilt design from GitHub instead of building it locally
+	make hardware//chisel
+	mkdir -p $(HW_BUILD_DIR)/$(BOARD)/project_vta/out
+	mkdir -p $(HW_BUILD_DIR)/$(BOARD)/chisel_project
+	mkdir -p $(HW_BUILD_DIR)/scala
+	./scripts/download-hw-data.sh $(BOARD) $(HW_BUILD_DIR)
+	make -t hardware/all
+
 .PHONY: hardware/clean
 hardware/clean:
 	$(MAKE) -C $(HW_ROOT_DIR) $(HW_MAKE_OPTS) clean
@@ -123,7 +132,6 @@ hardware/clean:
 .PHONY: hardware//%
 hardware//%: ## Forward rule to invoke hardware rules directly e.g. `make hardware//chisel`
 	$(MAKE) -C $(HW_ROOT_DIR) $(HW_MAKE_OPTS) $*
-
 # -----------------------------------------------------------------------------
 # Build boot image ------------------------------------------------------------
 # -----------------------------------------------------------------------------

--- a/scripts/download-hw-data.sh
+++ b/scripts/download-hw-data.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2021-2022 Western Digital Corporation or its affiliates
+# Copyright 2021-2022 Antmicro
+#
+# SPDX-License-Identifier: Apache-2.0
+
+function help()
+{
+	echo "Usage download-hw-data.sh <board> <hw-build-directory>"
+	echo
+	echo "Download prebuilt files from Alkali HW releases for a given <board>"
+	echo "and copy them to a proper place inside the <hw-build-directory>"
+}
+
+if [ "$#" -ne 2 ]; then
+	help
+	exit 1
+fi
+
+BOARD=$1
+BUILD_DIR=$2
+
+LINK_TO_RELEASES=https://github.com/antmicro/alkali-csd-hw/releases/download/v1.0
+
+BOARD_LOWERCASE=$(echo "${BOARD}" | tr '[:upper:]' '[:lower:]')
+PREBUILD_NAME="${LINK_TO_RELEASES}/${BOARD_LOWERCASE}.zip"
+DOWNLOAD_DIR="$(mktemp -d)"
+
+wget -O "${DOWNLOAD_DIR}/data.zip" "${PREBUILD_NAME}"
+unzip "${DOWNLOAD_DIR}/data.zip" -d "${DOWNLOAD_DIR}"
+mkdir -p "${BUILD_DIR}/${BOARD}/project_vta/out"
+cp "${DOWNLOAD_DIR}/${BOARD}"/* "${BUILD_DIR}/${BOARD}/project_vta/out"


### PR DESCRIPTION
The target can be used to download prebuilt files from GitHub instead of building them locally. In this way, you can build an entire project without vivado.