### PR TITLE
docs: Add dependencies to alkali.dockerfile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Setup Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8.5
+                  python-version: 3.9
             - name: Install dependencies
               run: |
                 export DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,12 +21,7 @@ jobs:
                 export DEBIAN_FRONTEND=noninteractive
                 sudo apt-get update
                 sudo apt-get install -y curl git rsync texlive-full
-                python -m pip install --upgrade \
-                    git+https://github.com/return42/linuxdoc \
-                    git+https://github.com/antmicro/sphinx_antmicro_theme.git \
-                    sphinx \
-                    docutils==0.16 \
-                    sphinx_tabs
+                python -m pip install --upgrade -r docs/requirements.txt
             - name: Generate documentation
               run: |
                 cd docs

--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,7 @@ $(DOCKER_BUILD_REGGEN_REQS_DIR):
 .PHONY: docker
 docker: alkali.dockerfile  ## Build the development docker image
 docker: requirements.txt
+docker: docs/requirements.txt
 docker: $(FW_ROOT_DIR)/requirements.txt
 docker: $(FW_ROOT_DIR)/apu-app/requirements.txt
 docker: $(REGGEN_DIR)/requirements.txt
@@ -291,6 +292,8 @@ docker: | $(DOCKER_BUILD_REGGEN_REQS_DIR)
 	cp $(ROOT_DIR)/requirements.txt $(DOCKER_BUILD_DIR)/requirements.txt
 	mkdir -p $(DOCKER_BUILD_REGGEN_REQS_DIR)
 	mkdir -p $(DOCKER_BUILD_FW_REQS_DIR)/apu-app
+	mkdir -p ${DOCKER_BUILD_DIR}/docs
+	cp ${ROOT_DIR}/docs/requirements.txt ${DOCKER_BUILD_DIR}/docs/requirements.txt
 	cp $(FW_ROOT_DIR)/requirements.txt $(DOCKER_BUILD_FW_REQS_DIR)/requirements.txt
 	cp $(FW_ROOT_DIR)/apu-app/requirements.txt $(DOCKER_BUILD_FW_REQS_DIR)/apu-app/requirements.txt
 	cp $(REGGEN_DIR)/requirements.txt $(DOCKER_BUILD_REGGEN_REQS_DIR)/requirements.txt

--- a/alkali.dockerfile
+++ b/alkali.dockerfile
@@ -58,6 +58,7 @@ RUN git clone -b v3.16.7 https://gitlab.kitware.com/cmake/cmake.git cmake && \
 
 # Install Python dependencies
 COPY requirements.txt requirements.txt
+COPY docs/requirements.txt docs/requirements.txt
 COPY alkali-csd-fw/requirements.txt alkali-csd-fw/requirements.txt
 COPY alkali-csd-fw/registers-generator/requirements.txt alkali-csd-fw/registers-generator/requirements.txt
 COPY alkali-csd-fw/apu-app/requirements.txt alkali-csd-fw/apu-app/requirements.txt

--- a/alkali.dockerfile
+++ b/alkali.dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
   wget \
   x11-xserver-utils \
   xsltproc \
+  texlive-full \
   && rm -rf /var/lib/apt/lists/*
 
 # Install rust

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+git+https://github.com/return42/linuxdoc
+git+https://github.com/antmicro/sphinx_antmicro_theme.git
+sphinx
+docutils==0.16
+sphinx_tabs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -r alkali-csd-fw/requirements.txt
+-r docs/requirements.txt


### PR DESCRIPTION
This PR adds dependecies to the alkali.dockerfile to enable building the project documentation from docker.